### PR TITLE
Zprec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,5 @@ dmypy.json
 \#*#
 .\#*#
 .\#*
+*.out
+*.prof

--- a/H-test.py
+++ b/H-test.py
@@ -39,8 +39,8 @@ Z = 1
 energy_1s = analytic_1s(light_speed, n, k, Z)
 print('Exact Energy',energy_1s - light_speed**2, flush = True)
 
-mra = vp.MultiResolutionAnalysis(box=[-20,20], order=10)
-prec = 1.0e-6
+mra = vp.MultiResolutionAnalysis(box=[-20,20], order=8)
+prec = 1.0e-4
 origin = [0.1, 0.2, 0.3]  # origin moved to avoid placing the nuclar charge on a node
 
 orb.orbital4c.light_speed = light_speed
@@ -74,8 +74,9 @@ while orbital_error > prec:
     add_psi.crop(prec/10)
     energy, imag = spinor_H.dot(add_psi)
     print('Energy',energy-light_speed**2,imag)
-    tmp = orb.apply_dirac_hamiltonian(v_psi, prec, energy)
-    new_orbital = orb.apply_helmholtz(tmp, energy, prec)
+    tmp = orb.apply_helmholtz(v_psi, energy, prec)
+    tmp.crop(prec/10)
+    new_orbital = orb.apply_dirac_hamiltonian(tmp, prec, energy)
     new_orbital.crop(prec/10)
     new_orbital.normalize()
     delta_psi = new_orbital - spinor_H

--- a/orbital4c/NuclearPotential.py
+++ b/orbital4c/NuclearPotential.py
@@ -1,0 +1,21 @@
+import numpy as np
+import copy as cp
+
+def CoulombPotential(position, center, charge):
+    distance = np.linalg.norm(positon - center)
+    potential = charge / distance
+
+def SmoothingHFYGB(Z, prec):
+    factor = 0.00435 * prec / Z**5
+    return factor**(1./3.)
+    
+def CoulombHFYGB(position, center, charge, precison):
+    distance = np.linalg.norm(positon - center)
+    factor = SmoothingHFYGB(charge, precision)
+    value = uHFYGB(distance / factor)
+    return charge * value / factor
+
+def uHFYGB(r):
+    u = erf(r)/r + (1/(3*np.sqrt(np.pi)))*(np.exp(-(r**2)) + 16*np.exp(-4*r**2))
+    return u
+

--- a/orbital4c/NuclearPotential.py
+++ b/orbital4c/NuclearPotential.py
@@ -1,16 +1,23 @@
 import numpy as np
 import copy as cp
+from scipy.special import erf
 
 def CoulombPotential(position, center, charge):
-    distance = np.linalg.norm(positon - center)
+    d2 = ((position[0] - center[0])**2 +
+          (position[1] - center[1])**2 +
+          (position[2] - center[2])**2)
+    distance = np.sqrt(d2)
     potential = charge / distance
 
 def SmoothingHFYGB(Z, prec):
     factor = 0.00435 * prec / Z**5
     return factor**(1./3.)
     
-def CoulombHFYGB(position, center, charge, precison):
-    distance = np.linalg.norm(positon - center)
+def CoulombHFYGB(position, center, charge, precision):
+    d2 = ((position[0] - center[0])**2 +
+          (position[1] - center[1])**2 +
+          (position[2] - center[2])**2)
+    distance = np.sqrt(d2)
     factor = SmoothingHFYGB(charge, precision)
     value = uHFYGB(distance / factor)
     return charge * value / factor

--- a/orbital4c/orbital.py
+++ b/orbital4c/orbital.py
@@ -205,10 +205,10 @@ class orbital4c:
 #                         [0, 0, -orbital4c.light_speed**2 + shift, 0 ],
 #                         [0, 0,  0, -orbital4c.light_speed**2 + shift]])
 #        out_orb.comp_array = beta@self.comp_array
-        beta = np.array([light_speed**2 + shift,
-                         light_speed**2 + shift,
-                        -light_speed**2 + shift,
-                        -light_speed**2 + shift])
+        beta = np.array([orbital4c.light_speed**2 + shift,
+                         orbital4c.light_speed**2 + shift,
+                        -orbital4c.light_speed**2 + shift,
+                        -orbital4c.light_speed**2 + shift])
         for idx in range(4):
             out_orb.comp_array[idx] = beta[idx] * self.comp_array[idx]
         return out_orb

--- a/orbital4c/orbital.py
+++ b/orbital4c/orbital.py
@@ -169,31 +169,48 @@ class orbital4c:
         vp.advanced.add(prec/10, exchange, add_vector)
         return exchange
 
-    def alpha(self,index):
+    def alpha(self,direction):
         out_orb = orbital4c()
-        alpha = np.array([[[0, 0, 0, 1],  
-                           [0, 0, 1, 0],
-                           [0, 1, 0, 0],
-                           [1, 0, 0, 0]],
-                          [[0,  0,  0,  -1j],
-                           [0,  0,  1j,  0],
-                           [0, -1j, 0,   0],
-                           [1j, 0,  0,   0]],
-                          [[0, 0, 1, 0],
-                           [0, 0, 0,-1],
-                           [1, 0, 0, 0],
-                           [0,-1, 0, 0]]])
-        out_orb.comp_array = alpha[index]@self.comp_array
+        alpha_order = np.array([[3, 2, 1, 0],
+                                [3, 2, 1, 0],
+                                [2, 3, 0, 1]])
+        
+        alpha_coeff = np.array([[ 1,  1,   1,  1],
+                                [-1j, 1j, -1j, 1j],
+                                [ 1, -1,   1, -1]])
+#        alpha = np.array([[[0, 0, 0, 1],
+#                           [0, 0, 1, 0],
+#                           [0, 1, 0, 0],
+#                           [1, 0, 0, 0]],
+#                          [[0,  0,  0,  -1j],
+#                           [0,  0,  1j,  0],
+#                           [0, -1j, 0,   0],
+#                           [1j, 0,  0,   0]],
+#                          [[0, 0, 1, 0],
+#                           [0, 0, 0,-1],
+#                           [1, 0, 0, 0],
+#                           [0,-1, 0, 0]]])
+#        out_orb.comp_array = alpha[direction]@self.comp_array
+        for idx in range(4):
+            coeff = alpha_coeff[direction][idx]
+            comp = alpha_order[direction][idx]
+            out_orb.comp_array[idx] = coeff * self.comp_array[comp]
         return out_orb
 
 #Beta c**2
     def beta(self, shift = 0):
         out_orb = orbital4c()
-        beta = np.array([[orbital4c.light_speed**2 + shift, 0, 0, 0  ],
-                         [0, orbital4c.light_speed**2 + shift, 0, 0  ],
-                         [0, 0, -orbital4c.light_speed**2 + shift, 0 ],
-                         [0, 0,  0, -orbital4c.light_speed**2 + shift]])
-        out_orb.comp_array = beta@self.comp_array
+#        beta = np.array([[orbital4c.light_speed**2 + shift, 0, 0, 0  ],
+#                         [0, orbital4c.light_speed**2 + shift, 0, 0  ],
+#                         [0, 0, -orbital4c.light_speed**2 + shift, 0 ],
+#                         [0, 0,  0, -orbital4c.light_speed**2 + shift]])
+#        out_orb.comp_array = beta@self.comp_array
+        beta = np.array([light_speed**2 + shift,
+                         light_speed**2 + shift,
+                        -light_speed**2 + shift,
+                        -light_speed**2 + shift])
+        for idx in range(4):
+            out_orb.comp_array[idx] = beta[idx] * self.comp_array[idx]
         return out_orb
     
     def dot(self, other):

--- a/orbital4c/orbital.py
+++ b/orbital4c/orbital.py
@@ -296,22 +296,3 @@ def one_s_alpha_comp(x,Z,alpha,gamma_factor,norm_const,comp):
     tmp3 = np.exp(-Z*r)
     values = one_s_alpha(x,Z,alpha,gamma_factor)
     return values[comp] * tmp2 * tmp3 * norm_const / np.sqrt(2*np.pi)
-
-def alpha(self,index):
-    out_orb = orbital4c()
-    alpha = np.array([[[0, 0, 0, 1],  
-                       [0, 0, 1, 0],
-                       [0, 1, 0, 0],
-                       [1, 0, 0, 0]],
-                      [[0,  0,  0,  -1j],
-                       [0,  0,  1j,  0],
-                       [0, -1j, 0,   0],
-                       [1j, 0,  0,   0]],
-                      [[0, 0, 1, 0],
-                       [0, 0, 0,-1],
-                       [1, 0, 0, 0],
-                       [0,-1, 0, 0]]])
-    out_orb.comp_array = alpha[index]@self.comp_array
-    return out_orb
-
-


### PR DESCRIPTION
Testing precision achieved with respect to different parameters: `prec`, `k`, `ghd` vs `hdg`

- [ ] switch from `hdg` to `ghd` from input
- [ ] move nuclear potential to separate file
- [ ] add uniform nucleus
- [ ] add fermi nucleus
- [ ] add gaussian nucleus