### PR TITLE
Restructure

### DIFF
--- a/orbital4c/complex_fcn.py
+++ b/orbital4c/complex_fcn.py
@@ -297,3 +297,16 @@ def scalar_times_r(function, prec):
         components[i] = apply_potential(1.0, r_i, function, prec)
         components[i].cropRealImag(prec)
     return components
+
+def vector_tensor_r(vector, prec):
+    tensor = []
+    for i in range(len(vector)):
+        tensor.append(scalar_times_r(vector[i], prec))
+    return tensor
+
+def vector_gradient(vector, der = "BS"):
+    tensor = []
+    for i in range(len(vector)):
+        tensor.append(vector[i].gradient(der))
+    return tensor
+

--- a/test.py
+++ b/test.py
@@ -200,7 +200,11 @@ if __name__ == '__main__':
     saveOrbitals = False
     runGaunt = False
     runGauge = False
-    runGaugeA = True
+    runGaugeA = False
+    runGaugeB = False
+    runGaugeC = True
+    runGaugeD = False
+    runGaugeDelta = False
     runTest = False
     default_der = args.deriv
     
@@ -259,6 +263,18 @@ if __name__ == '__main__':
         
     if runGaugeA:
         two_electron.calcGaugePertA(spinorb1, spinorb2, mra, prec)
+
+    if runGaugeB:
+        two_electron.calcGaugePertB(spinorb1, spinorb2, mra, prec)
+
+    if runGaugeC:
+        two_electron.calcGaugePertC(spinorb1, spinorb2, mra, prec)
+        
+    if runGaugeD:
+        two_electron.calcGaugePertD(spinorb1, spinorb2, mra, prec)
+        
+    if runGaugeDelta:
+        two_electron.calcGaugeDelta(spinorb1, spinorb2, mra, prec)
         
     if runTest:
         testConv(spinorb1, spinorb2, mra, length, prec)

--- a/test.py
+++ b/test.py
@@ -24,6 +24,7 @@ importlib.reload(orb)
 def calcGaugePotential(density, operator, direction, P): # direction is i index
 
     print("calc gauge pot ", direction)
+
     Bgauge = [cf.complex_fcn(), cf.complex_fcn(), cf.complex_fcn()]
     index = [[1, 0, 0],
              [0, 1, 0],
@@ -31,18 +32,12 @@ def calcGaugePotential(density, operator, direction, P): # direction is i index
     index[0][direction] += 1
     index[1][direction] += 1
     index[2][direction] += 1
-    for idx in range(3):
-        Bgauge[idx].real = operator(density[idx].real, index[idx][0], index[idx][1], index[idx][2])
-        Bgauge[idx].imag = operator(density[idx].imag, index[idx][0], index[idx][1], index[idx][2])
-        #    Bgauge[i].real = P(density[i].real)
-        #    Bgauge[i].imag = P(density[i].imag)
-        
-    out = Bgauge[0] + Bgauge[1] + Bgauge[2]
-#    out = Bgauge[idx]
-    del Bgauge
-    return out
+    for i in range(3): # j index
+        Bgauge[i].real = operator(density[i].real, index[i][0], index[i][1], index[i][2])
+        Bgauge[i].imag = operator(density[i].imag, index[i][0], index[i][1], index[i][2])
+    return Bgauge[0] + Bgauge[1] + Bgauge[2]
 
-#@profile
+@profile
 def gaugePert(spinorb1, spinorb2, mra, length, prec):
     
     P = vp.PoissonOperator(mra, prec)
@@ -51,7 +46,6 @@ def gaugePert(spinorb1, spinorb2, mra, length, prec):
     #Definition of alpha vectors for each orbital
     alpha1 =  spinorb1.alpha_vector(prec)
     alpha2 =  spinorb2.alpha_vector(prec)
-
     n22 = [spinorb2.overlap_density(alpha2[0], prec),
            spinorb2.overlap_density(alpha2[1], prec),
            spinorb2.overlap_density(alpha2[2], prec)]
@@ -59,14 +53,6 @@ def gaugePert(spinorb1, spinorb2, mra, length, prec):
     n21 = [spinorb2.overlap_density(alpha1[0], prec),
            spinorb2.overlap_density(alpha1[1], prec),
            spinorb2.overlap_density(alpha1[2], prec)]
-
-#    n22 = [make_dens(spinorb2, alpha2[0], prec),
-#           make_dens(spinorb2, alpha2[1], prec),
-#           make_dens(spinorb2, alpha2[2], prec)]
-
-#    n21 = [make_dens(spinorb2, alpha1[0], prec),
-#           make_dens(spinorb2, alpha1[1], prec),
-#           make_dens(spinorb2, alpha1[2], prec)]
 
     for i in range(3):
         n22[i].crop(prec)
@@ -142,7 +128,6 @@ def testConv(spinorb1, spinorb2, mra, length, prec):
         gaugeEnergy = gaugeEnergy - gaugeJr
     print("Gauge energy correction ", gaugeEnergy)
     return gaugeEnergy
-
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Collecting all data tostart the program.')
@@ -259,7 +244,6 @@ if __name__ == '__main__':
         spinorb1, spinorb2 = two_electron.coulomb_gs_2e(spinorb, V_tree, mra, prec)
     
     if runGaunt:
-#        two_electron.gauntPert(spinorb1, spinorb2, mra, prec)
         two_electron.calcGauntPert(spinorb1, spinorb2, mra, prec)
     
     if runGauge:

--- a/test.py
+++ b/test.py
@@ -198,8 +198,9 @@ if __name__ == '__main__':
     readOrbitals = True
     runCoulomb = False
     saveOrbitals = False
-    runGaunt = True
-    runGauge = True
+    runGaunt = False
+    runGauge = False
+    runGaugeA = True
     runTest = False
     default_der = args.deriv
     
@@ -255,6 +256,9 @@ if __name__ == '__main__':
     
     if runGauge:
         two_electron.calcGaugePert(spinorb1, spinorb2, mra, prec)
+        
+    if runGaugeA:
+        two_electron.calcGaugePertA(spinorb1, spinorb2, mra, prec)
         
     if runTest:
         testConv(spinorb1, spinorb2, mra, length, prec)

--- a/test.py
+++ b/test.py
@@ -32,12 +32,18 @@ def calcGaugePotential(density, operator, direction, P): # direction is i index
     index[0][direction] += 1
     index[1][direction] += 1
     index[2][direction] += 1
-    for i in range(3): # j index
-        Bgauge[i].real = operator(density[i].real, index[i][0], index[i][1], index[i][2])
-        Bgauge[i].imag = operator(density[i].imag, index[i][0], index[i][1], index[i][2])
-    return Bgauge[0] + Bgauge[1] + Bgauge[2]
+    for idx in range(3):
+        Bgauge[idx].real = operator(density[idx].real, index[idx][0], index[idx][1], index[idx][2])
+        Bgauge[idx].imag = operator(density[idx].imag, index[idx][0], index[idx][1], index[idx][2])
+        #    Bgauge[i].real = P(density[i].real)
+        #    Bgauge[i].imag = P(density[i].imag)
+        
+    out = Bgauge[0] + Bgauge[1] + Bgauge[2]
+#    out = Bgauge[idx]
+    del Bgauge
+    return out
 
-@profile
+#@profile
 def gaugePert(spinorb1, spinorb2, mra, length, prec):
     
     P = vp.PoissonOperator(mra, prec)
@@ -46,6 +52,7 @@ def gaugePert(spinorb1, spinorb2, mra, length, prec):
     #Definition of alpha vectors for each orbital
     alpha1 =  spinorb1.alpha_vector(prec)
     alpha2 =  spinorb2.alpha_vector(prec)
+
     n22 = [spinorb2.overlap_density(alpha2[0], prec),
            spinorb2.overlap_density(alpha2[1], prec),
            spinorb2.overlap_density(alpha2[2], prec)]

--- a/two_electron.py
+++ b/two_electron.py
@@ -102,7 +102,12 @@ def calcAlphaDensityVector(spinorb1, spinorb2, prec):
     alphaDensity[1].cropRealImag(prec)
     alphaDensity[2].cropRealImag(prec)
     return alphaDensity
-    
+
+#
+# currently without the -1/2 factor
+# correct gaun term: multiply by -1/2
+# gaunt and delta-term from gauge: multiply by -1
+#
 def calcGauntPert(spinorb1, spinorb2, mra, prec):
     print ("Gaunt Perturbation")
     P = vp.PoissonOperator(mra, prec)
@@ -180,14 +185,17 @@ def calcPerturbationValues(contributions, P, prec, testNorm):
         normDensity = np.sqrt(density.squaredNorm())
         normAuxDensity = np.sqrt(auxDensity.squaredNorm())
         threshold = 0.00001 * prec * testNorm / normDensity
-#        threshold = 0
-#        print("threshold ", i, threshold, normDensity, normAuxDensity)
         potential = (cf.apply_poisson(auxDensity, auxDensity.mra, P, prec, thresholdNorm = threshold, factor = sign))
         spr, spi = density.dot(potential, conjugate)
         print(spr, spi)
         val += spr + 1j * spi
     return val
     
+#
+# currently without the -1/2 factor
+# correct gauge term: multiply by -1/2
+# no delta terms from this expression
+#
 def calcGaugePertA(spinorb1, spinorb2, mra, prec):
     print("Gauge Perturbation Version A")
     projection_operator = vp.ScalingProjector(mra, prec)
@@ -225,8 +233,6 @@ def calcGaugePertA(spinorb1, spinorb2, mra, prec):
                      n21_r_mat[0][0], n21_r_mat[0][1], n21_r_mat[0][2],
                      n21_r_mat[1][0], n21_r_mat[1][1], n21_r_mat[1][2],
                      n21_r_mat[2][0], n21_r_mat[2][1], n21_r_mat[2][2]],
-#        "sign":[ 1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-#                 1, -1, -1, -1, -1, -1, -1, -1, -1, -1]
         "sign":[-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
                  1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
     } 
@@ -237,6 +243,12 @@ def calcGaugePertA(spinorb1, spinorb2, mra, prec):
     print("final Gauge A", result)
     return result
 
+#
+# currently without the -1/2 factor
+# correct gauge term: multiply by -1/2
+# one delta term excluded
+# most efficient method
+#
 def calcGaugePertB(spinorb1, spinorb2, mra, prec):
     print("Gauge Perturbation Version B")
     projection_operator = vp.ScalingProjector(mra, prec)
@@ -272,6 +284,13 @@ def calcGaugePertB(spinorb1, spinorb2, mra, prec):
     print("final Gauge B", result)
     return result
 
+#
+# currently without the -1/2 factor
+# correct gauge term: multiply by -1/2
+# one delta term excluded
+# same structure as Sun 2022
+# least efficeint method
+#
 def calcGaugePertC(spinorb1, spinorb2, mra, prec):
     print("Gauge Perturbation Version C")
     projection_operator = vp.ScalingProjector(mra, prec)
@@ -332,6 +351,11 @@ def calcGaugePertC(spinorb1, spinorb2, mra, prec):
     print("final Gauge C", result)
     return result
 
+#
+# currently without the -1/2 factor
+# correct gauge term: multiply by -1/2
+# double delta term excluded
+#
 def calcGaugePertD(spinorb1, spinorb2, mra, prec):
     print("Gauge Perturbation Version D")
     projection_operator = vp.ScalingProjector(mra, prec)
@@ -383,6 +407,10 @@ def calcGaugePertD(spinorb1, spinorb2, mra, prec):
     print("final Gauge D", result)
     return result
 
+#
+# currently without the -1/2 factor
+# correct gauge delta term: multiply by -1/2
+#
 def calcGaugeDelta(spinorb1, spinorb2, mra, prec):
     print("Gauge Perturbation Delta")
     projection_operator = vp.ScalingProjector(mra, prec)

--- a/two_electron.py
+++ b/two_electron.py
@@ -280,26 +280,22 @@ def gaugePert(spinorb1, spinorb2, mra, length, prec):
     print("Gauge energy correction ", gaugeEnergy)
     return gaugeEnergy
 
+def calcAlphaDensityVector(spinorb1, spinorb2, prec):
+    alphaOrbital =  spinorb2.alpha_vector(prec)
+    alphaDensity = [spinorb1.overlap_density(alphaOrbital[0], prec),
+                    spinorb1.overlap_density(alphaOrbital[1], prec),
+                    spinorb1.overlap_density(alphaOrbital[2], prec)]
+    del alphaOrbital
+    alphaDensity[0].cropRealImag(prec)
+    alphaDensity[1].cropRealImag(prec)
+    alphaDensity[2].cropRealImag(prec)
+    return alphaDensity
+    
 def calcGaugePert(spinorb1, spinorb2, mra, prec):
     print("Gauge Perturbation (Xiaosong Li version)")
     projection_operator = vp.ScalingProjector(mra, prec)
-    alpha1 =  spinorb1.alpha_vector(prec)
-    n21 = [spinorb2.overlap_density(alpha1[0], prec),
-           spinorb2.overlap_density(alpha1[1], prec),
-           spinorb2.overlap_density(alpha1[2], prec)]
-    del alpha1
-    alpha2 =  spinorb2.alpha_vector(prec)
-    n22 = [spinorb2.overlap_density(alpha2[0], prec),
-           spinorb2.overlap_density(alpha2[1], prec),
-           spinorb2.overlap_density(alpha2[2], prec)]
-    del alpha2
-    
-    n21[0].cropRealImag(prec)
-    n21[1].cropRealImag(prec)
-    n21[2].cropRealImag(prec)
-    n22[0].cropRealImag(prec)
-    n22[1].cropRealImag(prec)
-    n22[2].cropRealImag(prec)
+    n21 = calcAlphaDesnsityVector(spinorb2, spinorb1, prec)
+    n22 = calcAlphaDesnsityVector(spinorb2, spinorb2, prec)
     
     P = vp.PoissonOperator(mra, prec)
     

--- a/two_electron.py
+++ b/two_electron.py
@@ -292,7 +292,6 @@ def calcGaugePert(spinorb1, spinorb2, mra, prec):
            spinorb2.overlap_density(alpha1[1], prec),
            spinorb2.overlap_density(alpha1[2], prec)]
     del alpha1
-
     alpha2 =  spinorb2.alpha_vector(prec)
     n22 = [spinorb2.overlap_density(alpha2[0], prec),
            spinorb2.overlap_density(alpha2[1], prec),
@@ -468,4 +467,3 @@ def calcGauntPert(spinorb1, spinorb2, mra, prec):
     print("Exchange part ", EK)
 
     print('GJmK_11_r', EJt - EKt)
-

--- a/two_electron.py
+++ b/two_electron.py
@@ -259,7 +259,11 @@ def gaugePert(spinorb1, spinorb2, mra, length, prec):
     R3O = r3m.GaugeOperator(mra, 1e-5, length, prec)
 
     Bgauge22 = [calcGaugePotential(n22, R3O, 0), calcGaugePotential(n22, R3O, 1), calcGaugePotential(n22, R3O, 2)]
+    print("Bgauge22")
+    print(Bgauge22[0], Bgauge22[1], Bgauge22[2])
     Bgauge21 = [calcGaugePotential(n21, R3O, 0), calcGaugePotential(n21, R3O, 1), calcGaugePotential(n21, R3O, 2)]
+    print("Bgauge21")
+    print(Bgauge21[0], Bgauge21[1], Bgauge21[2])
 
     # the following idientites hold for two orbitals connected by KTRS
     # n_11[i] == -n22[i]
@@ -464,5 +468,4 @@ def calcGauntPert(spinorb1, spinorb2, mra, prec):
     print("Exchange part ", EK)
 
     print('GJmK_11_r', EJt - EKt)
-
 

--- a/two_electron.py
+++ b/two_electron.py
@@ -92,194 +92,6 @@ def coulomb_gs_2e(spinorb1, potential, mra, prec, der = 'ABGV'):
             compute_last_energy = True
     return(spinorb1, spinorb2)
 
-def gauntPert(spinorb1, spinorb2, mra, prec):
-    
-    P = vp.PoissonOperator(mra, prec)
-    Light_speed = spinorb1.light_speed
-
-    #Definition of alpha vectors for each orbital
-    print("calculating alpha phi")
-    alpha1_0 =  spinorb1.alpha(0, prec)
-    alpha1_1 =  spinorb1.alpha(1, prec)
-    alpha1_2 =  spinorb1.alpha(2, prec)
-
-    alpha2_0 =  spinorb2.alpha(0, prec)
-    alpha2_1 =  spinorb2.alpha(1, prec)
-    alpha2_2 =  spinorb2.alpha(2, prec)
-
-    #Defintion of orbital * alpha(orbital)
-    n21_0 = spinorb2.overlap_density(alpha1_0, prec)
-    n21_1 = spinorb2.overlap_density(alpha1_1, prec)
-    n21_2 = spinorb2.overlap_density(alpha1_2, prec)
-   
-    n22_0 = spinorb2.overlap_density(alpha2_0, prec)
-    n22_1 = spinorb2.overlap_density(alpha2_1, prec)
-    n22_2 = spinorb2.overlap_density(alpha2_2, prec)
-
-    norm22 = [np.sqrt(n22_0.squaredNorm()),
-              np.sqrt(n22_1.squaredNorm()),
-              np.sqrt(n22_2.squaredNorm())
-            ]
-
-    norm21 = [np.sqrt(n21_0.squaredNorm()),
-              np.sqrt(n21_1.squaredNorm()),
-              np.sqrt(n21_2.squaredNorm())
-            ]
-
-    print(norm22)
-    print(norm21)
-    
-    n11_0 = spinorb1.overlap_density(alpha1_0, prec)
-    n11_1 = spinorb1.overlap_density(alpha1_1, prec)
-    n11_2 = spinorb1.overlap_density(alpha1_2, prec)
-   
-    n12_0 = spinorb1.overlap_density(alpha2_0, prec)
-    n12_1 = spinorb1.overlap_density(alpha2_1, prec)
-    n12_2 = spinorb1.overlap_density(alpha2_2, prec)
-    
-    #Definition of Gaunt two electron operators       
-    print("calculating potentials")
-    BG22_Re0 = P(n22_0.real) * (4.0 * np.pi)
-    BG22_Re1 = P(n22_1.real) * (4.0 * np.pi)
-    BG22_Re2 = P(n22_2.real) * (4.0 * np.pi)
-    BG22_Im0 = P(n22_0.imag) * (4.0 * np.pi)
-    BG22_Im1 = P(n22_1.imag) * (4.0 * np.pi)
-    BG22_Im2 = P(n22_2.imag) * (4.0 * np.pi)
-    
-    BG21_Re0 = P(n21_0.real) * (4.0 * np.pi)
-    BG21_Re1 = P(n21_1.real) * (4.0 * np.pi)
-    BG21_Re2 = P(n21_2.real) * (4.0 * np.pi)
-    BG21_Im0 = P(n21_0.imag) * (4.0 * np.pi)
-    BG21_Im1 = P(n21_1.imag) * (4.0 * np.pi)
-    BG21_Im2 = P(n21_2.imag) * (4.0 * np.pi)
-    
-    BG22_0 = cf.complex_fcn()
-    BG22_0.real = BG22_Re0
-    BG22_0.imag = BG22_Im0
-    
-    BG22_1 = cf.complex_fcn()
-    BG22_1.real = BG22_Re1
-    BG22_1.imag = BG22_Im1
-    
-    BG22_2 = cf.complex_fcn()
-    BG22_2.real = BG22_Re2
-    BG22_2.imag = BG22_Im2
-    
-    BG21_0 = cf.complex_fcn()
-    BG21_0.real = BG21_Re0
-    BG21_0.imag = BG21_Im0
-    
-    BG21_1 = cf.complex_fcn()
-    BG21_1.real = BG21_Re1
-    BG21_1.imag = BG21_Im1
-    
-    BG21_2 = cf.complex_fcn()
-    BG21_2.real = BG21_Re2
-    BG21_2.imag = BG21_Im2
-
-    # Calculation of Gaunt two electron terms 
-    print("applying potentials")
-    #    VGJ2_0 = orb.apply_complex_potential(1.0, BG22_0, alpha1_0, prec)
-    #    VGJ2_1 = orb.apply_complex_potential(1.0, BG22_1, alpha1_1, prec)
-    #    VGJ2_2 = orb.apply_complex_potential(1.0, BG22_2, alpha1_2, prec)
-    #    GJ2_alpha1 = VGJ2_0 + VGJ2_1 + VGJ2_2
-
-    EJ_0 = (n11_0.complex_conj()).dot(BG22_0)
-    EJ_1 = (n11_1.complex_conj()).dot(BG22_1)
-    EJ_2 = (n11_2.complex_conj()).dot(BG22_2)
-    
-    EK_0 = (n12_0.complex_conj()).dot(BG21_0)
-    EK_1 = (n12_1.complex_conj()).dot(BG21_1)
-    EK_2 = (n12_2.complex_conj()).dot(BG21_2)
-
-    print("Pot norm BG22_0", BG22_0.squaredNorm(), n22_0.squaredNorm(), EJ_0)
-    print("Pot norm BG21_0", BG21_0.squaredNorm(), n21_0.squaredNorm(), EK_0)
-    print("Pot norm BG22_1", BG22_1.squaredNorm(), n22_1.squaredNorm(), EJ_1)
-    print("Pot norm BG21_1", BG21_1.squaredNorm(), n21_1.squaredNorm(), EK_1)
-    print("Pot norm BG22_2", BG22_2.squaredNorm(), n22_2.squaredNorm(), EJ_2)
-    print("Pot norm BG21_2", BG21_2.squaredNorm(), n21_2.squaredNorm(), EK_2)
-
-    print(n22_0)
-    print(BG22_0)
-    print("Direct part   ", EJ_0, EJ_1, EJ_2)
-    print("Exchange part ", EK_0, EK_1, EK_2)
-    
-    EJ = EJ_0[0] + EJ_1[0] + EJ_2[0]
-    EK = EK_0[0] + EK_1[0] + EK_2[0]
-
-#    Vgk2_0 = orb.apply_complex_potential(1.0, BG21_0, alpha2_0, prec)
-#    VGK2_1 = orb.apply_complex_potential(1.0, BG21_1, alpha2_1, prec)
-#    VGK2_2 = orb.apply_complex_potential(1.0, BG21_2, alpha2_2, prec)
-#    GK2_alpha1 = VGK2_0 + VGK2_1 + VGK2_2
-
-    # change of sign!
-#    GJmK_phi1 = GK2_alpha1 - GJ2_alpha1
-    
-#    print("computing exp value")
-#    GJmK_11_r, GJmK_11_i = spinorb1.dot(GJmK_phi1)
-
-    print('GJmK_11_r', EK - EJ)
-
-
-def calcGaugePotential(density, operator, direction, poisson): # direction is i index
-    
-    Bgauge = [cf.complex_fcn(), cf.complex_fcn(), cf.complex_fcn()]
-    index = [[1, 0, 0],
-             [0, 1, 0],
-             [0, 0, 1]]
-    index[0][direction] += 1
-    index[1][direction] += 1
-    index[2][direction] += 1
-    for i in range(3): # j index
-        Bgauge[i].real = operator(density[i].real, index[i][0], index[i][1], index[i][2])
-        Bgauge[i].imag = operator(density[i].imag, index[i][0], index[i][1], index[i][2])
-#        Bgauge[i].real = poisson(density[i].real)
-#        Bgauge[i].imag = poisson(density[i].imag)
-        
-
-    return Bgauge[0] + Bgauge[1] + Bgauge[2]
-
-def gaugePert(spinorb1, spinorb2, mra, length, prec):
-    print("Gauge Perturbation")
-    #P = vp.PoissonOperator(mra, prec)       Non serve
-    #light_speed = spinorb1.light_speed    Non serve
-
-    #Definition of alpha vectors for each orbital
-
-    n21 = [spinorb2.overlap_density(alpha1[0], prec),
-           spinorb2.overlap_density(alpha1[1], prec),
-           spinorb2.overlap_density(alpha1[2], prec)]
-    del alpha1
-    n22 = [spinorb2.overlap_density(alpha2[0], prec),
-           spinorb2.overlap_density(alpha2[1], prec),
-           spinorb2.overlap_density(alpha2[2], prec)]
-    del alpha2
-
-    #Definition of Gauge operator
-    R3O = r3m.GaugeOperator(mra, 1e-5, length, prec)
-
-    Bgauge22 = [calcGaugePotential(n22, R3O, 0), calcGaugePotential(n22, R3O, 1), calcGaugePotential(n22, R3O, 2)]
-    Bgauge21 = [calcGaugePotential(n21, R3O, 0), calcGaugePotential(n21, R3O, 1), calcGaugePotential(n21, R3O, 2)]
-
-    # the following idientites hold for two orbitals connected by KTRS
-    # n_11[i] == -n22[i]
-    # n_12[i] ==  n21[i].complex_conj()
-
-    gaugeEnergy = 0
-
-    for i in range(3): 
-        Bgauge22 = calcGaugePotential(n22, R3O, i, P)
-        Bgauge21 = calcGaugePotential(n21, R3O, i, P)
-        gaugeJr, gaugeJi = n22[i].complex_conj().dot(Bgauge22)
-        gaugeKr, gaugeKi = n21[i].dot(Bgauge21)
-        print("Direct   ", gaugeJr, gaugeJi)
-        print("Exchange ", gaugeKr, gaugeKi)
-        gaugeEnergy = gaugeEnergy - 0.5 * (gaugeJr + gaugeKr)
-        del Bgauge22
-        del Bgauge21
-    print("Gauge energy correction ", gaugeEnergy)
-    return gaugeEnergy
-
 def calcAlphaDensityVector(spinorb1, spinorb2, prec):
     alphaOrbital =  spinorb2.alpha_vector(prec)
     alphaDensity = [spinorb1.overlap_density(alphaOrbital[0], prec),
@@ -291,140 +103,36 @@ def calcAlphaDensityVector(spinorb1, spinorb2, prec):
     alphaDensity[2].cropRealImag(prec)
     return alphaDensity
     
-def calcGaugePert(spinorb1, spinorb2, mra, prec):
-    print("Gauge Perturbation (Xiaosong Li version)")
-    projection_operator = vp.ScalingProjector(mra, prec)
-    n21 = calcAlphaDensityVector(spinorb2, spinorb1, prec)
-    n22 = calcAlphaDensityVector(spinorb2, spinorb2, prec)
-    
-    P = vp.PoissonOperator(mra, prec)
-    
-    div_n22 = cf.divergence(n22, prec)
-    div_n21 = cf.divergence(n21, prec)
-    n22_dot_r = cf.vector_dot_r(n22, prec)
-    n21_dot_r = cf.vector_dot_r(n21, prec)
-    div_n22_r = cf.scalar_times_r(div_n22, prec)
-    div_n21_r = cf.scalar_times_r(div_n21, prec)
-    
-    norm22 = {
-        "nx":np.sqrt(n22[0].squaredNorm()),
-        "ny":np.sqrt(n22[1].squaredNorm()),
-        "nz":np.sqrt(n22[2].squaredNorm()),
-        "divn":np.sqrt(div_n22.squaredNorm()),
-        "ndotr":np.sqrt(n22_dot_r.squaredNorm()),
-        "divnx":np.sqrt(div_n22_r[0].squaredNorm()),
-        "divny":np.sqrt(div_n22_r[1].squaredNorm()),
-        "divnz":np.sqrt(div_n22_r[2].squaredNorm())
-    }
-    
-    norm21 = {
-        "nx":np.sqrt(n21[0].squaredNorm()),
-        "ny":np.sqrt(n21[1].squaredNorm()),
-        "nz":np.sqrt(n21[2].squaredNorm()),
-        "divn":np.sqrt(div_n21.squaredNorm()),
-        "ndotr":np.sqrt(n21_dot_r.squaredNorm()),
-        "divnx":np.sqrt(div_n21_r[0].squaredNorm()),
-        "divny":np.sqrt(div_n21_r[1].squaredNorm()),
-        "divnz":np.sqrt(div_n21_r[2].squaredNorm())
-    }
-    
-    print(norm22)
-    print(norm21)
-    
-    val22 = norm22["nx"] * norm22["divnx"] + norm22["ny"] * norm22["divny"] + norm22["nz"] * norm22["divnz"] + norm22["ndotr"] * norm22["divn"]
-    val21 = norm21["nx"] * norm21["divnx"] + norm21["ny"] * norm21["divny"] + norm21["nz"] * norm21["divnz"] + norm21["ndotr"] * norm21["divn"]
-    val = val21 + val22
-    
-    print("val", val)
-    # the following idientites hold for two orbitals connected by KTRS
-    # n_11[i] == -n22[i]
-    # n_12[i] ==  n21[i].complex_conj()
-    
-    print("Potentials")
-    print("n11 term")
-    threshold = 0.01 * prec * val / norm22["ndotr"]
-    print("threshold 22", threshold)
-    V_div_n11 = cf.apply_poisson(div_n22, div_n22.mra, P, prec, thresholdNorm = threshold, factor = -1.0)
-    
-    print("n12 term")
-    threshold = 0.01 * prec * val / norm21["ndotr"] 
-    print("threshold 21", threshold)
-    V_div_n12 = (cf.apply_poisson(div_n21, div_n21.mra, P, prec, thresholdNorm = threshold, factor = -1.0)).complex_conj()
-    
-    V_div_n11_r = {}
-    V_div_n12_r = {}
-    
-    n1label = ["nx", "ny", "nz"]
-    
-    for i in range(3):
-        print("Potentials",i)
-        print("n11 term")
-        threshold = 0.01 * prec * val / norm22[n1label[i]]
-        print("threshold 22", threshold)
-        V_div_n11_r[i] = cf.apply_poisson(div_n22_r[i], div_n22_r[i].mra, P, prec, thresholdNorm = threshold, factor = 1.0)
-    
-        print("n12 term")
-        threshold = 0.01 * prec * val / norm21[n1label[i]]
-        print("threshold 21", threshold)
-        V_div_n12_r[i] = (cf.apply_poisson(div_n21_r[i], div_n21_r[i].mra, P, prec, thresholdNorm = threshold, factor = 1.0)).complex_conj()
-    
-    print("scalar products")
-    n22_dot_r_V_div_n11r, n22_dot_r_V_div_n11i = n22_dot_r.dot(V_div_n11, False)
-    n21_dot_r_V_div_n12r, n21_dot_r_V_div_n12i = n21_dot_r.dot(V_div_n12, False)    
-
-    result_22_11 = n22_dot_r_V_div_n11r + 1j * n22_dot_r_V_div_n11i
-    result_21_12 = n21_dot_r_V_div_n12r + 1j * n21_dot_r_V_div_n12i
-    print("result before loop")
-    print(result_22_11)
-    print(result_21_12)
-
-    for i in range(3):
-        result_22_11r, result_22_11i = n22[i].dot(V_div_n11_r[i], False)
-        result_21_12r, result_21_12i = n21[i].dot(V_div_n12_r[i], False)
-        print("in loop",i)
-        print(result_22_11r, result_22_11i)
-        print(result_21_12r, result_21_12i)
-        result_22_11 += result_22_11r + 1j * result_22_11i
-        result_21_12 += result_21_12r + 1j * result_21_12i
-    print("Final direct ", result_22_11)
-    print("Final exchange ", result_21_12)
-    print("Total ",  result_22_11 - result_21_12)
-
 def calcGauntPert(spinorb1, spinorb2, mra, prec):
     print ("Gaunt Perturbation")
     P = vp.PoissonOperator(mra, prec)
-    Light_speed = spinorb1.light_speed
     alpha1 =  spinorb1.alpha_vector(prec)
-    n21 = [spinorb2.overlap_density(alpha1[0], prec),
-           spinorb2.overlap_density(alpha1[1], prec),
-           spinorb2.overlap_density(alpha1[2], prec)]
-    del alpha1
-    
-    alpha2 =  spinorb2.alpha_vector(prec)
-    n22 = [spinorb2.overlap_density(alpha2[0], prec),
-           spinorb2.overlap_density(alpha2[1], prec),
-           spinorb2.overlap_density(alpha2[2], prec)]
-    del alpha2
-    
-    n21[0].cropRealImag(prec)
-    n21[1].cropRealImag(prec)
-    n21[2].cropRealImag(prec)
-    n22[0].cropRealImag(prec)
-    n22[1].cropRealImag(prec)
-    n22[2].cropRealImag(prec)
+    n11 = calcAlphaDensityVector(spinorb1, spinorb1, prec)
+    n12 = calcAlphaDensityVector(spinorb1, spinorb2, prec)
+    n21 = calcAlphaDensityVector(spinorb2, spinorb1, prec)
+    n22 = calcAlphaDensityVector(spinorb2, spinorb2, prec)
 
     norm22 = [np.sqrt(n22[0].squaredNorm()),
               np.sqrt(n22[1].squaredNorm()),
               np.sqrt(n22[2].squaredNorm())
             ]
-
     norm21 = [np.sqrt(n21[0].squaredNorm()),
               np.sqrt(n21[1].squaredNorm()),
               np.sqrt(n21[2].squaredNorm())
             ]
+    norm11 = [np.sqrt(n11[0].squaredNorm()),
+              np.sqrt(n11[1].squaredNorm()),
+              np.sqrt(n11[2].squaredNorm())
+            ]
+    norm12 = [np.sqrt(n12[0].squaredNorm()),
+              np.sqrt(n12[1].squaredNorm()),
+              np.sqrt(n12[2].squaredNorm())
+            ]
 
-    print(norm22)
+    print(norm11)
+    print(norm12)
     print(norm21)
+    print(norm22)
     
     val22 = 0
     val21 = 0
@@ -434,26 +142,20 @@ def calcGauntPert(spinorb1, spinorb2, mra, prec):
     val = val21 + val22
     
     print("calculating potentials")
-    BG22 = []
-    BG21 = []
     EJ = []
     EK = []
     EJt = 0
     EKt = 0
     for i in range(3):
-        threshold = 0.01 * prec * val / norm22[i]
-        pot = cf.apply_poisson(n22[i], n22[i].mra, P, prec, thresholdNorm = threshold, factor = 1)
-        BG22.append(pot)
-        EJ.append(n22[i].dot(BG22[i], False))
+        threshold = 0.0001 * prec * val / norm22[i]
+        pot = cf.apply_poisson(n11[i], n11[i].mra, P, prec, thresholdNorm = threshold, factor = 1)
+        EJ.append(n22[i].dot(pot, False))
         EJt += EJ[i][0] + 1j * EJ[i][1]
-        print("pot norm 22", i, BG22[i].squaredNorm(), n22[i].squaredNorm(), EJ[i])
 
-        threshold = 0.01 * prec * val / norm21[i]
-        pot = (cf.apply_poisson(n21[i], n21[i].mra, P, prec, thresholdNorm = threshold, factor = -1)).complex_conj()
-        BG21.append(pot)
-        EK.append(n21[i].dot(BG21[i], False))
+        threshold = 0.0001 * prec * val / norm21[i]
+        pot = (cf.apply_poisson(n12[i], n12[i].mra, P, prec, thresholdNorm = threshold, factor = 1))
+        EK.append(n21[i].dot(pot, False))
         EKt += EK[i][0] + 1j * EK[i][1]
-        print("pot norm 21", i, BG21[i].squaredNorm(), n21[i].squaredNorm(), EK[i])
 
     print("Direct part   ", EJ)
     print("Exchange part ", EK)

--- a/two_electron.py
+++ b/two_electron.py
@@ -259,11 +259,7 @@ def gaugePert(spinorb1, spinorb2, mra, length, prec):
     R3O = r3m.GaugeOperator(mra, 1e-5, length, prec)
 
     Bgauge22 = [calcGaugePotential(n22, R3O, 0), calcGaugePotential(n22, R3O, 1), calcGaugePotential(n22, R3O, 2)]
-    print("Bgauge22")
-    print(Bgauge22[0], Bgauge22[1], Bgauge22[2])
     Bgauge21 = [calcGaugePotential(n21, R3O, 0), calcGaugePotential(n21, R3O, 1), calcGaugePotential(n21, R3O, 2)]
-    print("Bgauge21")
-    print(Bgauge21[0], Bgauge21[1], Bgauge21[2])
 
     # the following idientites hold for two orbitals connected by KTRS
     # n_11[i] == -n22[i]


### PR DESCRIPTION
1. All four varaints of the Gauge term implemented, starting from the Sun 2022 paper.

2. All densities now computed explicitly without relying on KTRS both for Gaunt and Gauge. This is strictly not necessary, but it avoids a lot of possible errrors (no need to keep track of signs and complex conjugation)

3. The four Gauge formulas differ by a contribution which has the same structure as the Gaunt.
- formula A: included (Gaunt untouched)
- formulas B and C: explicitly removed once (Gaunt should be multiplied by a factor 2)
- formula D: it is explicitly removed twice (Gaunt should be multiplied by a factor 3)

4. Formula C corresponds to (B6) in the [Sun paper (https://doi.org/10.1063/5.0098828)].

5. None of the formulas contain the factor -1/2 which is necessary to obtain the correct final result. It can be included if need be

6. The most efficient expression (B) is obtained when nabla operates on the density which is NOT involved in the scalar product with r12. In this way all nablas become divergences contracting one of the indices before the Poisson operator is applied. This can be achieved by selecting which of the two electrons nabla operates on (with a change of sign). Surprisingly Sun etal. have made the opposite choice. It might be that with AOs there is not much to gain either way.
